### PR TITLE
set explicitly the C++ standard to use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if(UNIX)
 endif()
 
 
+# set explicitly the c++ standard to use
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
+
 # add src dir to included directories
 include_directories(src)
 


### PR DESCRIPTION
New C++11 standard is started to be used by default on some distros (e.g. arch). In order to avoid any problems with building on these distros, C++ standard flag should be set explicitly to ~~c++98~~ c++03.